### PR TITLE
feat: choose-tenant gate + branch step + lock prod register (#46)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,6 +4,10 @@ BASE_URL=http://localhost:3000
 # Required in production — used to sign access tokens (change the dev default).
 JWT_SECRET=change-me-to-a-long-random-string
 
+# Open registration on POST /api/auth/register: allowed by default in non-production.
+# In production, registration is disabled unless set to true.
+# ALLOW_OPEN_REGISTRATION=true
+
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
 DATABASE_NAME=drug_store

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -1,21 +1,27 @@
 import { Module } from "@nestjs/common";
 import { JwtModule } from "@nestjs/jwt";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { Tenant } from "../../entities/tenant.entity";
+import { UserMembership } from "../../entities/user-membership.entity";
 import { User } from "../../entities/user.entity";
+import { TenancyModule } from "../tenancy/tenancy.module";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { getJwtSecret } from "./jwt-secret";
+import { SessionController } from "./session.controller";
+import { SessionService } from "./session.service";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User]),
+    TenancyModule,
+    TypeOrmModule.forFeature([User, UserMembership, Tenant]),
     JwtModule.register({
       secret: getJwtSecret(),
       signOptions: { expiresIn: "7d" },
     }),
   ],
-  controllers: [AuthController],
-  providers: [AuthService],
+  controllers: [AuthController, SessionController],
+  providers: [AuthService, SessionService],
   exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.service.test.ts
+++ b/apps/api/src/modules/auth/auth.service.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { ForbiddenException } from "@nestjs/common";
+import type { JwtService } from "@nestjs/jwt";
+import type { Repository } from "typeorm";
+import type { User } from "../../entities/user.entity";
+import { AuthService } from "./auth.service";
+
+describe("AuthService.register open registration policy", () => {
+  const prevNodeEnv = process.env.NODE_ENV;
+  const prevAllow = process.env.ALLOW_OPEN_REGISTRATION;
+
+  afterEach(() => {
+    process.env.NODE_ENV = prevNodeEnv;
+    process.env.ALLOW_OPEN_REGISTRATION = prevAllow;
+  });
+
+  it("forbids register in production by default", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ALLOW_OPEN_REGISTRATION = undefined;
+    const service = new AuthService({} as Repository<User>, {} as JwtService);
+    await assert.rejects(
+      () => service.register({ email: "a@b.com", password: "longenough" }),
+      ForbiddenException,
+    );
+  });
+
+  it("allows register in production when ALLOW_OPEN_REGISTRATION=true", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ALLOW_OPEN_REGISTRATION = "true";
+    const usersRepo = {
+      exists: async () => false,
+      create: (u: Partial<User>) => u as User,
+      save: async (u: User) => u,
+    } as unknown as Repository<User>;
+    const jwtService = {
+      signAsync: async () => "jwt",
+    } as unknown as JwtService;
+    const service = new AuthService(usersRepo, jwtService);
+    const res = await service.register({ email: "new@example.com", password: "longenough" });
+    assert.ok(res.accessToken);
+  });
+});

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -1,4 +1,9 @@
-import { ConflictException, Injectable, UnauthorizedException } from "@nestjs/common";
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from "@nestjs/common";
 // biome-ignore lint/style/useImportType: NestJS DI requires a runtime import for reflect-metadata injection
 import { JwtService } from "@nestjs/jwt";
 import { InjectRepository } from "@nestjs/typeorm";
@@ -24,6 +29,17 @@ export class AuthService {
     return email.trim().toLowerCase();
   }
 
+  /** Production disables open registration unless `ALLOW_OPEN_REGISTRATION=true`. Non-production allows unless `ALLOW_OPEN_REGISTRATION=false`. */
+  private assertOpenRegistrationAllowed(): void {
+    const isProd = process.env.NODE_ENV === "production";
+    const allow =
+      (!isProd && process.env.ALLOW_OPEN_REGISTRATION !== "false") ||
+      (isProd && process.env.ALLOW_OPEN_REGISTRATION === "true");
+    if (!allow) {
+      throw new ForbiddenException("Open registration is disabled. Use an invite link to join.");
+    }
+  }
+
   async signToken(user: User): Promise<string> {
     return this.jwtService.signAsync({
       sub: user.id,
@@ -36,6 +52,7 @@ export class AuthService {
   }
 
   async register(dto: RegisterDto): Promise<AuthResponse> {
+    this.assertOpenRegistrationAllowed();
     const email = this.normalizeEmail(dto.email);
     const exists = await this.usersRepo.exists({ where: { email } });
     if (exists) {

--- a/apps/api/src/modules/auth/session.controller.ts
+++ b/apps/api/src/modules/auth/session.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Inject, UseGuards } from "@nestjs/common";
+import { ApiTags } from "@nestjs/swagger";
+import type { AuthContext } from "../tenancy/auth-context";
+import { AllowTenantless, AuthContextParam } from "../tenancy/auth.decorators";
+import { AuthGuard } from "../tenancy/auth.guard";
+import type { SessionBootstrapDto } from "./session.service";
+import { SessionService } from "./session.service";
+
+@Controller("me")
+@ApiTags("Session")
+@UseGuards(AuthGuard)
+export class SessionController {
+  constructor(
+    @Inject(SessionService)
+    private readonly sessionService: SessionService,
+  ) {}
+
+  @Get("session")
+  @AllowTenantless()
+  async getSession(@AuthContextParam() context: AuthContext): Promise<SessionBootstrapDto> {
+    return this.sessionService.getBootstrap(context.userId);
+  }
+}

--- a/apps/api/src/modules/auth/session.service.ts
+++ b/apps/api/src/modules/auth/session.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import type { Repository } from "typeorm";
+import { Tenant } from "../../entities/tenant.entity";
+import { UserMembership } from "../../entities/user-membership.entity";
+import { User } from "../../entities/user.entity";
+
+export type SessionMembershipDto = {
+  role: string;
+  branchId: string | null;
+};
+
+export type SessionTenantDto = {
+  id: string;
+  name: string;
+  memberships: SessionMembershipDto[];
+};
+
+export type SessionBootstrapDto = {
+  isPlatformAdmin: boolean;
+  tenants: SessionTenantDto[];
+};
+
+@Injectable()
+export class SessionService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(UserMembership)
+    private readonly membershipRepo: Repository<UserMembership>,
+    @InjectRepository(Tenant)
+    private readonly tenantRepo: Repository<Tenant>,
+  ) {}
+
+  async getBootstrap(userId: string | undefined): Promise<SessionBootstrapDto> {
+    if (!userId) {
+      throw new UnauthorizedException("Missing user identity");
+    }
+    const user = await this.userRepo.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new UnauthorizedException("User not found");
+    }
+
+    if (user.platformAdmin === true) {
+      const tenants = await this.tenantRepo.find({ order: { name: "ASC" } });
+      return {
+        isPlatformAdmin: true,
+        tenants: tenants.map((t) => ({
+          id: t.id,
+          name: t.name,
+          memberships: [],
+        })),
+      };
+    }
+
+    const memberships = await this.membershipRepo.find({
+      where: { userId },
+      relations: { tenant: true },
+      order: { tenantId: "ASC", createdAt: "ASC" },
+    });
+
+    const byTenant = new Map<
+      string,
+      { id: string; name: string; memberships: SessionMembershipDto[] }
+    >();
+    for (const m of memberships) {
+      const tid = m.tenantId;
+      if (!byTenant.has(tid)) {
+        byTenant.set(tid, {
+          id: tid,
+          name: m.tenant.name,
+          memberships: [],
+        });
+      }
+      const row = byTenant.get(tid);
+      if (row) {
+        row.memberships.push({
+          role: m.role,
+          branchId: m.branchId,
+        });
+      }
+    }
+
+    return {
+      isPlatformAdmin: false,
+      tenants: [...byTenant.values()].sort((a, b) => a.name.localeCompare(b.name)),
+    };
+  }
+}

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -1,2 +1,5 @@
 # API base URL (no trailing slash). API defaults to PORT=3051 in `apps/api/.env`.
 NEXT_PUBLIC_API_URL=http://localhost:3051
+
+# Show self-serve register link / page in production builds (API must also allow registration).
+# NEXT_PUBLIC_ENABLE_REGISTER=true

--- a/apps/dashboard/src/app/choose-tenant/page.tsx
+++ b/apps/dashboard/src/app/choose-tenant/page.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { branchesApi, sessionApi } from "@/lib/api";
+import { useAuthContext } from "@/lib/auth-context";
+import type { BranchDto, SessionBootstrapDto, SessionTenantDto } from "@drug-store/shared";
+import {
+  autoSelectBranchId,
+  branchIdsForTenant,
+  needsBranchSelectionStep,
+  rolesForTenant,
+} from "@drug-store/shared";
+import { Alert, Button, Card, CardContent, CardHeader, CardTitle, Select } from "@drug-store/ui";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+
+type Step = "loading" | "tenant" | "branch" | "empty";
+
+function ChooseTenantWizard() {
+  const { state, updateState } = useAuthContext();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const nextPath = searchParams.get("next")?.trim() || "/";
+  const bootstrapLoaded = useRef(false);
+
+  useEffect(() => {
+    if (!state.accessToken) {
+      bootstrapLoaded.current = false;
+    }
+  }, [state.accessToken]);
+
+  const [step, setStep] = useState<Step>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [bootstrap, setBootstrap] = useState<SessionBootstrapDto | null>(null);
+  const [branchList, setBranchList] = useState<BranchDto[]>([]);
+  const [activeTenant, setActiveTenant] = useState<SessionTenantDto | null>(null);
+  const [selectedBranchId, setSelectedBranchId] = useState("");
+
+  const finishAndNavigate = useCallback(
+    (tenant: SessionTenantDto, bootstrapData: SessionBootstrapDto, activeBranch: string | null) => {
+      updateState({
+        tenantId: tenant.id,
+        roles: rolesForTenant(tenant, bootstrapData.isPlatformAdmin),
+        branchIds: branchIdsForTenant(tenant),
+        activeBranchId: activeBranch,
+        onboardingComplete: true,
+      });
+      router.replace(nextPath.startsWith("/") ? nextPath : "/");
+    },
+    [nextPath, router, updateState],
+  );
+
+  const prepareBranchStep = useCallback(
+    async (tenant: SessionTenantDto, data: SessionBootstrapDto) => {
+      updateState({
+        tenantId: tenant.id,
+        roles: rolesForTenant(tenant, data.isPlatformAdmin),
+        branchIds: branchIdsForTenant(tenant),
+        activeBranchId: null,
+      });
+      setActiveTenant(tenant);
+      const branches = await branchesApi.listBranches();
+      setBranchList(branches);
+      const ids = tenant.memberships
+        .map((m) => m.branchId)
+        .filter((b): b is string => typeof b === "string" && b.length > 0);
+      const unique = [...new Set(ids)];
+      if (unique.length > 0) {
+        setSelectedBranchId(unique[0] ?? "");
+      }
+      setStep("branch");
+    },
+    [updateState],
+  );
+
+  const applyTenant = useCallback(
+    async (tenant: SessionTenantDto, data: SessionBootstrapDto) => {
+      setError(null);
+      const needBranch = needsBranchSelectionStep(tenant, data.isPlatformAdmin);
+      const autoBranch = autoSelectBranchId(tenant, data.isPlatformAdmin);
+      if (needBranch) {
+        try {
+          await prepareBranchStep(tenant, data);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : "Failed to load branches");
+          setStep("tenant");
+        }
+        return;
+      }
+      finishAndNavigate(tenant, data, autoBranch);
+    },
+    [finishAndNavigate, prepareBranchStep],
+  );
+
+  useEffect(() => {
+    if (!state.accessToken) {
+      router.replace("/login");
+    }
+  }, [state.accessToken, router]);
+
+  useEffect(() => {
+    if (!state.accessToken || state.onboardingComplete || bootstrapLoaded.current) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setError(null);
+      setStep("loading");
+      try {
+        const data = await sessionApi.getBootstrap();
+        if (cancelled) return;
+        bootstrapLoaded.current = true;
+        setBootstrap(data);
+        if (data.tenants.length === 0) {
+          setStep("empty");
+          return;
+        }
+        if (data.tenants.length === 1) {
+          const only = data.tenants[0];
+          if (!only) {
+            setStep("empty");
+            return;
+          }
+          const needBranch = needsBranchSelectionStep(only, data.isPlatformAdmin);
+          const autoBranch = autoSelectBranchId(only, data.isPlatformAdmin);
+          if (needBranch) {
+            try {
+              await prepareBranchStep(only, data);
+            } catch (err) {
+              if (!cancelled) {
+                setError(err instanceof Error ? err.message : "Failed to load branches");
+                setStep("tenant");
+              }
+            }
+            return;
+          }
+          finishAndNavigate(only, data, autoBranch);
+          return;
+        }
+        setStep("tenant");
+      } catch (err) {
+        if (!cancelled) {
+          bootstrapLoaded.current = false;
+          setError(err instanceof Error ? err.message : "Could not load organizations");
+          setStep("tenant");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [state.accessToken, state.onboardingComplete, finishAndNavigate, prepareBranchStep]);
+
+  if (!state.accessToken) {
+    return (
+      <p className="text-sm text-on_surface_variant" aria-live="polite">
+        Redirecting…
+      </p>
+    );
+  }
+
+  if (state.onboardingComplete) {
+    router.replace(nextPath.startsWith("/") ? nextPath : "/");
+    return (
+      <p className="text-sm text-on_surface_variant" aria-live="polite">
+        Loading…
+      </p>
+    );
+  }
+
+  if (step === "loading") {
+    return (
+      <p className="text-sm text-on_surface_variant" aria-live="polite">
+        Loading organizations…
+      </p>
+    );
+  }
+
+  if (step === "empty") {
+    return (
+      <Card className="w-full max-w-md border border-outline_variant/15 shadow-tonal">
+        <CardHeader>
+          <CardTitle>No organizations</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-on_surface_variant">
+          <p>
+            Your account is not linked to any tenant yet. Contact an administrator for an invite.
+          </p>
+          <Button type="button" variant="secondary" onClick={() => router.replace("/login")}>
+            Back to sign in
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (step === "branch" && activeTenant && bootstrap) {
+    const ids = activeTenant.memberships
+      .map((m) => m.branchId)
+      .filter((b): b is string => typeof b === "string" && b.length > 0);
+    const unique = [...new Set(ids)];
+    const nameById = new Map(branchList.map((b) => [b.id, b.name]));
+
+    return (
+      <Card className="w-full max-w-lg border border-outline_variant/15 shadow-tonal">
+        <CardHeader>
+          <CardTitle>Choose branch</CardTitle>
+          <p className="text-sm font-normal text-on_surface_variant">
+            You have access to multiple branches in {activeTenant.name}. Pick where you are working
+            now.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error ? <Alert variant="destructive">{error}</Alert> : null}
+          <div className="space-y-2">
+            <label htmlFor="branch-choice" className="text-sm font-medium text-on_surface">
+              Branch
+            </label>
+            <Select
+              id="branch-choice"
+              value={selectedBranchId}
+              onChange={(e) => setSelectedBranchId(e.target.value)}
+            >
+              {unique.map((id) => (
+                <option key={id} value={id}>
+                  {nameById.get(id) ?? id}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <Button
+            type="button"
+            className="w-full"
+            disabled={!selectedBranchId}
+            onClick={() => finishAndNavigate(activeTenant, bootstrap, selectedBranchId)}
+          >
+            Continue
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (step === "tenant" && bootstrap && bootstrap.tenants.length > 1) {
+    return (
+      <Card className="w-full max-w-lg border border-outline_variant/15 shadow-tonal">
+        <CardHeader>
+          <CardTitle>Choose organization</CardTitle>
+          <p className="text-sm font-normal text-on_surface_variant">
+            Select which organization you want to use for this session.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error ? <Alert variant="destructive">{error}</Alert> : null}
+          <ul className="space-y-2">
+            {bootstrap.tenants.map((tenant) => (
+              <li key={tenant.id}>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="h-auto w-full justify-between py-3 text-left"
+                  onClick={() => void applyTenant(tenant, bootstrap)}
+                >
+                  <span className="font-medium text-on_surface">{tenant.name}</span>
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <p className="text-sm text-on_surface_variant" aria-live="polite">
+      Preparing…
+    </p>
+  );
+}
+
+export default function ChooseTenantPage() {
+  return (
+    <Suspense
+      fallback={
+        <p className="text-sm text-on_surface_variant" aria-live="polite">
+          Loading…
+        </p>
+      }
+    >
+      <ChooseTenantWizard />
+    </Suspense>
+  );
+}

--- a/apps/dashboard/src/app/invite/[token]/page.tsx
+++ b/apps/dashboard/src/app/invite/[token]/page.tsx
@@ -47,8 +47,9 @@ export default function AcceptInvitePage() {
         roles: [],
         branchIds: [],
         activeBranchId: null,
+        onboardingComplete: false,
       });
-      router.replace("/");
+      router.replace("/choose-tenant");
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : "Failed to accept invite");
     } finally {

--- a/apps/dashboard/src/app/login/page.tsx
+++ b/apps/dashboard/src/app/login/page.tsx
@@ -20,9 +20,10 @@ function LoginForm() {
 
   useEffect(() => {
     if (state.accessToken) {
-      router.replace(next.startsWith("/") ? next : "/");
+      const q = next && next !== "/" ? `?next=${encodeURIComponent(next)}` : "";
+      router.replace(state.onboardingComplete === false ? `/choose-tenant${q}` : next);
     }
-  }, [state.accessToken, next, router]);
+  }, [state.accessToken, state.onboardingComplete, next, router]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -38,8 +39,10 @@ function LoginForm() {
         roles: [],
         branchIds: [],
         activeBranchId: null,
+        onboardingComplete: false,
       });
-      router.replace(next.startsWith("/") ? next : "/");
+      const q = next && next !== "/" ? `?next=${encodeURIComponent(next)}` : "";
+      router.replace(`/choose-tenant${q}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Sign in failed");
     } finally {
@@ -91,12 +94,15 @@ function LoginForm() {
           <Button type="submit" className="w-full" disabled={loading}>
             {loading ? "Signing in…" : "Sign in"}
           </Button>
-          <p className="text-center text-sm text-on_surface_variant">
-            No account?{" "}
-            <Link href="/register" className="font-medium text-primary hover:underline">
-              Register
-            </Link>
-          </p>
+          {(process.env.NODE_ENV !== "production" ||
+            process.env.NEXT_PUBLIC_ENABLE_REGISTER === "true") && (
+            <p className="text-center text-sm text-on_surface_variant">
+              No account?{" "}
+              <Link href="/register" className="font-medium text-primary hover:underline">
+                Register
+              </Link>
+            </p>
+          )}
         </form>
       </CardContent>
     </Card>

--- a/apps/dashboard/src/app/register/page.tsx
+++ b/apps/dashboard/src/app/register/page.tsx
@@ -7,6 +7,9 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
+const allowRegisterUi =
+  process.env.NODE_ENV !== "production" || process.env.NEXT_PUBLIC_ENABLE_REGISTER === "true";
+
 export default function RegisterPage() {
   const { state, updateState } = useAuthContext();
   const router = useRouter();
@@ -17,13 +20,21 @@ export default function RegisterPage() {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    if (state.accessToken) {
-      router.replace("/");
+    if (!allowRegisterUi) {
+      router.replace("/login");
     }
-  }, [state.accessToken, router]);
+  }, [router]);
+
+  useEffect(() => {
+    if (state.accessToken) {
+      const q = "";
+      router.replace(state.onboardingComplete === false ? `/choose-tenant${q}` : "/");
+    }
+  }, [state.accessToken, state.onboardingComplete, router]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!allowRegisterUi) return;
     setError(null);
     setLoading(true);
     try {
@@ -36,14 +47,23 @@ export default function RegisterPage() {
         roles: [],
         branchIds: [],
         activeBranchId: null,
+        onboardingComplete: false,
       });
-      router.replace("/");
+      router.replace("/choose-tenant");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Registration failed");
     } finally {
       setLoading(false);
     }
   };
+
+  if (!allowRegisterUi) {
+    return (
+      <p className="text-sm text-on_surface_variant" aria-live="polite">
+        Redirecting…
+      </p>
+    );
+  }
 
   return (
     <Card className="w-full max-w-md border border-outline_variant/15 shadow-tonal">

--- a/apps/dashboard/src/components/app-chrome.tsx
+++ b/apps/dashboard/src/components/app-chrome.tsx
@@ -8,7 +8,10 @@ import { usePathname } from "next/navigation";
 export function AppChrome({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isAuthRoute =
-    pathname === "/login" || pathname === "/register" || pathname.startsWith("/invite/");
+    pathname === "/login" ||
+    pathname === "/register" ||
+    pathname === "/choose-tenant" ||
+    pathname.startsWith("/invite/");
 
   if (isAuthRoute) {
     return (

--- a/apps/dashboard/src/components/auth-gate.tsx
+++ b/apps/dashboard/src/components/auth-gate.tsx
@@ -13,13 +13,26 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     if (!state.accessToken) {
       const next = pathname && pathname !== "/" ? `?next=${encodeURIComponent(pathname)}` : "";
       router.replace(`/login${next}`);
+      return;
     }
-  }, [state.accessToken, pathname, router]);
+    if (state.onboardingComplete === false) {
+      const next = pathname && pathname !== "/" ? `?next=${encodeURIComponent(pathname)}` : "";
+      router.replace(`/choose-tenant${next}`);
+    }
+  }, [state.accessToken, state.onboardingComplete, pathname, router]);
 
   if (!state.accessToken) {
     return (
       <div className="flex min-h-screen flex-1 items-center justify-center bg-surface">
         <p className="text-sm text-on_surface_variant">Signing in…</p>
+      </div>
+    );
+  }
+
+  if (state.onboardingComplete === false) {
+    return (
+      <div className="flex min-h-screen flex-1 items-center justify-center bg-surface">
+        <p className="text-sm text-on_surface_variant">Choose your organization…</p>
       </div>
     );
   }

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -11,6 +11,7 @@ import {
   patientsApi,
   purchaseOrdersApi,
   salesApi,
+  sessionApi,
   stockCountsApi,
   supplierReturnsApi,
   suppliersApi,
@@ -29,6 +30,7 @@ const apiUrl =
 if (apiUrl) {
   authApi.configure({ apiBaseUrl: apiUrl });
   invitesApi.configure({ apiBaseUrl: apiUrl });
+  sessionApi.configure({ apiBaseUrl: apiUrl, getAuthHeaders });
   const options = { apiBaseUrl: apiUrl, getAuthHeaders };
   patientsApi.configure(options);
   medicinesApi.configure(options);
@@ -67,4 +69,5 @@ export {
   supplierReturnsApi,
   authApi,
   invitesApi,
+  sessionApi,
 };

--- a/apps/dashboard/src/lib/auth-storage.ts
+++ b/apps/dashboard/src/lib/auth-storage.ts
@@ -8,6 +8,8 @@ export type DevAuthState = {
   roles: UserRole[];
   branchIds: string[];
   activeBranchId?: string | null;
+  /** False until user finishes /choose-tenant (tenant + optional branch). */
+  onboardingComplete: boolean;
 };
 
 const STORAGE_KEY = "pharma-dev-auth";
@@ -20,6 +22,7 @@ const defaultState: DevAuthState = {
   roles: [],
   branchIds: [],
   activeBranchId: null,
+  onboardingComplete: true,
 };
 
 export const readAuthState = (): DevAuthState => {
@@ -40,6 +43,12 @@ export const readAuthState = (): DevAuthState => {
       typeof parsed.accessToken === "string" && parsed.accessToken.length > 0
         ? parsed.accessToken
         : null;
+    const hasLegacyTenant =
+      typeof parsed.tenantId === "string" && parsed.tenantId.trim().length > 0;
+    const onboardingComplete =
+      typeof parsed.onboardingComplete === "boolean"
+        ? parsed.onboardingComplete
+        : hasLegacyTenant;
     return {
       ...defaultState,
       ...parsed,
@@ -47,6 +56,7 @@ export const readAuthState = (): DevAuthState => {
       roles: Array.isArray(parsed.roles) ? (parsed.roles as UserRole[]) : defaultState.roles,
       branchIds: Array.isArray(parsed.branchIds) ? parsed.branchIds : defaultState.branchIds,
       activeBranchId: normalizedActiveBranchId,
+      onboardingComplete,
     };
   } catch {
     return defaultState;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -66,6 +66,19 @@ export type {
 } from "./types/tenancy";
 export type { AuthResponseDto, AuthUserDto } from "./types/auth";
 export type {
+  SessionBootstrapDto,
+  SessionMembershipDto,
+  SessionTenantDto,
+} from "./types/session";
+export {
+  autoSelectBranchId,
+  branchIdsForTenant,
+  distinctBranchIds,
+  needsBranchSelectionStep,
+  rolesForTenant,
+  tenantHasHqWideAccess,
+} from "./lib/tenant-wizard";
+export type {
   CreatePoPendingBranchApprovalNotificationInput,
   NotificationDispatchResult,
   NotificationDto,
@@ -164,5 +177,6 @@ export { TaxesApi, taxesApi } from "./lib/taxesApi";
 export { SalesApi, salesApi } from "./lib/salesApi";
 export { TransfersApi, transfersApi } from "./lib/transfersApi";
 export { AuthApi, authApi } from "./lib/authApi";
+export { SessionApi, sessionApi } from "./lib/sessionApi";
 export { InvitesApi, invitesApi } from "./lib/invitesApi";
 export type { InviteLookupDto, AcceptInviteInput } from "./lib/invitesApi";

--- a/packages/shared/src/lib/sessionApi.ts
+++ b/packages/shared/src/lib/sessionApi.ts
@@ -1,0 +1,38 @@
+import type { SessionBootstrapDto } from "../types/session";
+
+export class SessionApi {
+  private apiBaseUrl: string | null = null;
+  private getAuthHeaders?: () => Record<string, string>;
+
+  configure(options: { apiBaseUrl?: string; getAuthHeaders?: () => Record<string, string> }) {
+    this.apiBaseUrl = options.apiBaseUrl ?? null;
+    this.getAuthHeaders = options.getAuthHeaders;
+  }
+
+  private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
+    if (!this.apiBaseUrl) {
+      throw new Error("Session API not configured (apiBaseUrl required)");
+    }
+    const url = `${this.apiBaseUrl.replace(/\/$/, "")}${path.startsWith("/") ? path : `/${path}`}`;
+    const authHeaders = this.getAuthHeaders?.() ?? {};
+    const res = await fetch(url, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders,
+        ...(options.headers as Record<string, string>),
+      },
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`API error: ${res.status} ${text}`);
+    }
+    return res.json();
+  }
+
+  async getBootstrap(): Promise<SessionBootstrapDto> {
+    return this.request<SessionBootstrapDto>("/api/me/session");
+  }
+}
+
+export const sessionApi = new SessionApi();

--- a/packages/shared/src/lib/tenant-wizard.ts
+++ b/packages/shared/src/lib/tenant-wizard.ts
@@ -1,0 +1,46 @@
+import type { SessionTenantDto } from "../types/session";
+import type { UserRole } from "../types/tenancy";
+
+const HQ_WIDE_ROLES: UserRole[] = ["hq_admin", "hq_user", "platform_admin"];
+
+export function tenantHasHqWideAccess(tenant: SessionTenantDto, isPlatformAdmin: boolean): boolean {
+  if (isPlatformAdmin) return true;
+  return tenant.memberships.some((m) => HQ_WIDE_ROLES.includes(m.role));
+}
+
+export function distinctBranchIds(tenant: SessionTenantDto): string[] {
+  return [...new Set(tenant.memberships.map((m) => m.branchId).filter(Boolean))] as string[];
+}
+
+/** Branch picker only when the user has more than one branch membership and no HQ-wide role. */
+export function needsBranchSelectionStep(
+  tenant: SessionTenantDto,
+  isPlatformAdmin: boolean,
+): boolean {
+  if (tenantHasHqWideAccess(tenant, isPlatformAdmin)) {
+    return false;
+  }
+  return distinctBranchIds(tenant).length > 1;
+}
+
+/** When exactly one branch membership, return that branch id. */
+export function autoSelectBranchId(
+  tenant: SessionTenantDto,
+  isPlatformAdmin: boolean,
+): string | null {
+  if (tenantHasHqWideAccess(tenant, isPlatformAdmin)) {
+    return null;
+  }
+  const ids = distinctBranchIds(tenant);
+  if (ids.length === 1) return ids[0] ?? null;
+  return null;
+}
+
+export function rolesForTenant(tenant: SessionTenantDto, isPlatformAdmin: boolean): UserRole[] {
+  if (isPlatformAdmin) return ["platform_admin"];
+  return [...new Set(tenant.memberships.map((m) => m.role))];
+}
+
+export function branchIdsForTenant(tenant: SessionTenantDto): string[] {
+  return [...new Set(tenant.memberships.map((m) => m.branchId).filter(Boolean))] as string[];
+}

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -1,0 +1,17 @@
+import type { UserRole } from "./tenancy";
+
+export type SessionMembershipDto = {
+  role: UserRole;
+  branchId: string | null;
+};
+
+export type SessionTenantDto = {
+  id: string;
+  name: string;
+  memberships: SessionMembershipDto[];
+};
+
+export type SessionBootstrapDto = {
+  isPlatformAdmin: boolean;
+  tenants: SessionTenantDto[];
+};


### PR DESCRIPTION
## Implements [issue #46](https://github.com/NathyG2524/pharma-bet/issues/46)

### Dashboard
- New full-screen **`/choose-tenant`** (no sidebar): loads **`GET /api/me/session`** for tenants + memberships.
- **Multi-tenant**: explicit tenant choice; **single tenant**: auto-continues into branch resolution.
- **Branch step**: only when the user is **not** HQ-wide (`hq_admin` / `hq_user` / `platform_admin`) and has **more than one** distinct branch membership; **one branch** auto-selects; HQ-wide **skips** branch UI.
- **`onboardingComplete`** in local auth state (with legacy migration: existing sessions that already have `tenantId` are treated as complete).
- **AuthGate** redirects authenticated users with incomplete onboarding to `/choose-tenant` (supports `?next=`).
- **Login / register / invite** set `onboardingComplete: false` and route through `/choose-tenant` (invite accepts no longer land on home with empty tenant).
- **Production**: hide **Register** link on login; **`/register`** redirects to `/login\** unless `NEXT_PUBLIC_ENABLE_REGISTER=true`.

### API
- **`GET /api/me/session`**: JWT-only, tenantless; returns bootstrap for tenant/branch wizard.
- **`POST /api/auth/register`**: forbidden in **production** by default; enable with `ALLOW_OPEN_REGISTRATION=true` (non-prod defaults to allowed unless `ALLOW_OPEN_REGISTRATION=false`).

### Shared
- `SessionApi`, `SessionBootstrapDto` types, `tenant-wizard` helpers.

### Tests
- `auth.service.test.ts`: register policy in production.

### Docs
- `apps/api/.env.example` and `apps/dashboard/.env.example` updated for flags.

Made with [Cursor](https://cursor.com)